### PR TITLE
Connect weapon damage with projectile and simple enemy

### DIFF
--- a/Assets/StarterAssets/ThirdPersonController/Scripts/Projectile.cs
+++ b/Assets/StarterAssets/ThirdPersonController/Scripts/Projectile.cs
@@ -10,6 +10,7 @@ public class Projectile : MonoBehaviour
     [SerializeField] private Transform _defaultImpact = null;
 
     private float _damage = 1f;
+    public float damage { get { return _damage; } }
     private bool _intitialized = false;
     private Character _shooter = null;
     private Rigidbody _rigidbody = null;

--- a/Assets/StarterAssets/ThirdPersonController/Scripts/SimpleEnemy.cs
+++ b/Assets/StarterAssets/ThirdPersonController/Scripts/SimpleEnemy.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+public class SimpleEnemy : MonoBehaviour
+{
+    [SerializeField] private int maxHealth = 100;
+    private int currentHealth;
+
+    private void Awake()
+    {
+        currentHealth = maxHealth;
+    }
+
+    public void ApplyDamage(float damage)
+    {
+        currentHealth -= Mathf.RoundToInt(damage);
+        if (currentHealth <= 0)
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        Projectile projectile = other.GetComponent<Projectile>();
+        if (projectile != null)
+        {
+            ApplyDamage(projectile.damage);
+            Destroy(other.gameObject);
+        }
+    }
+}

--- a/Assets/StarterAssets/ThirdPersonController/Scripts/SimpleEnemy.cs.meta
+++ b/Assets/StarterAssets/ThirdPersonController/Scripts/SimpleEnemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d96dd8784bc04df6b29c2d313ca87fe4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- expose damage value from `Projectile`
- add a simple enemy example that receives damage from `Projectile`

## Testing
- `dotnet --version` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68487b0117a88333b359875baa9c436a